### PR TITLE
chore(dotnet): migrate solution to dotnet 8

### DIFF
--- a/AccountCreatedConsumer/AccountCreatedConsumer.csproj
+++ b/AccountCreatedConsumer/AccountCreatedConsumer.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AllEventsConsumer/AllEventsConsumer.csproj
+++ b/AllEventsConsumer/AllEventsConsumer.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AmountDepositedConsumer/AmountDepositedConsumer.csproj
+++ b/AmountDepositedConsumer/AmountDepositedConsumer.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/EjemploEventSourcing.API/Dockerfile
+++ b/EjemploEventSourcing.API/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:5.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["EjemploEventSourcing.API/EjemploEventSourcing.API.csproj", "EjemploEventSourcing.API/"]
 RUN dotnet restore "EjemploEventSourcing.API/EjemploEventSourcing.API.csproj"

--- a/EjemploEventSourcing.API/EjemploEventSourcing.API.csproj
+++ b/EjemploEventSourcing.API/EjemploEventSourcing.API.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>7162a66d-a70c-4ef7-82b0-d7d4156d1fba</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.13" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EjemploEventSourcing.Infrastructure/EjemploEventSourcing.Infrastructure.csproj
+++ b/EjemploEventSourcing.Infrastructure/EjemploEventSourcing.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EjemploEventSourcing.IoC/EjemploEventSourcing.IoC.csproj
+++ b/EjemploEventSourcing.IoC/EjemploEventSourcing.IoC.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EjemploEventSourcing/EjemploEventSourcing.Application.csproj
+++ b/EjemploEventSourcing/EjemploEventSourcing.Application.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.4" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.1.4" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.6.2" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Application\Domain\" />


### PR DESCRIPTION
## Summary

Migrates the solution from .NET 5 to .NET 8 so it builds with the supported SDK installed locally.

## Changes

- Retargeted all projects from net5.0 to net8.0.
- Updated NuGet package references for EF Core, Npgsql, RabbitMQ.Client, Swashbuckle, and Microsoft.Extensions abstractions.
- Updated the API Dockerfile to use .NET 8 SDK/runtime images.

## Why

.NET 5 is out of support and the repository did not compile with the current local SDK. This creates a supported baseline before refactoring the Event Sourcing flow.

## Scope

- [ ] Docs
- [ ] API
- [ ] Domain / Events
- [ ] Persistence
- [ ] Messaging
- [x] Infra / Config

## Testing

- [ ] Manual
- [ ] Unit tests
- [x] Not applicable

Validation run:

- dotnet build EjemploEventSourcing.sln

Result: build succeeded with 7 existing warnings related to async usage, throw ex, and migration type naming.

## Notes

This PR intentionally does not fix async/event-publisher behavior. Those changes should be handled in focused follow-up PRs.