### PR TITLE
fix(async): await event persistence flow

### DIFF
--- a/EjemploEventSourcing.API/Controllers/CreateAccountController.cs
+++ b/EjemploEventSourcing.API/Controllers/CreateAccountController.cs
@@ -24,7 +24,7 @@ namespace EjemploEventSourcing.IPresenters
         public async Task<IActionResult> Post()
         {
             var id = Guid.NewGuid();
-            _interactor.Execute(id.ToString());
+            await _interactor.Execute(id.ToString());
             return Ok(id);
         }
     }

--- a/EjemploEventSourcing.API/Controllers/DepositAmountController.cs
+++ b/EjemploEventSourcing.API/Controllers/DepositAmountController.cs
@@ -22,7 +22,7 @@ namespace EjemploEventSourcing.IPresenters
         [HttpPost]
         public async Task<IActionResult> Post(DepositAmountModel model)
         {
-            _interactor.Execute(model.AccountId, model.DepositAmount);
+            await _interactor.Execute(model.AccountId, model.DepositAmount);
             return Ok();
         }
     }

--- a/EjemploEventSourcing/Application/Domain/Events/Services/DomainEventsPublisher.cs
+++ b/EjemploEventSourcing/Application/Domain/Events/Services/DomainEventsPublisher.cs
@@ -40,24 +40,24 @@ namespace EjemploEventSourcing.Application.Domain.Events.Services
             _suscribers = Enumerable.Empty<IDomainEventsSuscriber>().ToList();
         }
 
-        public void PublishEvent(IAggregateInfo aggregateInfo, int eventVersion, IEvent e)
+        public async Task PublishEvent(IAggregateInfo aggregateInfo, int eventVersion, IEvent e)
         {
             var suscribers = _suscribers.Where(x => x.SuscribeTo().Any(y => y == e.GetEventType())).ToList();
 
 
             foreach (var suscriber in suscribers) 
             {
-                suscriber.ManageEvent(aggregateInfo, eventVersion, e);
+                await suscriber.ManageEvent(aggregateInfo, eventVersion, e);
             }
         }
 
-        public void PublishEvents(IChangesInAggregateInfo changes)
+        public async Task PublishEvents(IChangesInAggregateInfo changes)
         {
             var increment = 1;
             foreach (var e in changes.Events)
             {
                 var eventVersion = changes.AggregateInfo.AggregateBaseVersion + increment;
-                PublishEvent(changes.AggregateInfo, eventVersion, e);
+                await PublishEvent(changes.AggregateInfo, eventVersion, e);
                 increment++;
             }
         }

--- a/EjemploEventSourcing/Application/Interactors/CreateAccount/CreateAccountInteractor.cs
+++ b/EjemploEventSourcing/Application/Interactors/CreateAccount/CreateAccountInteractor.cs
@@ -7,14 +7,14 @@ namespace EjemploEventSourcing.Application.Interactors.CreateAccount
 {
     public class CreateAccountInteractor : ICreateAccountInteractor
     {
-        public void Execute(string id)
+        public async Task Execute(string id)
         {
             var account = Account.CreateAccount(id);
 
             if (account.HasChanges())
             {
                 var changes = account.GetChanges();
-                DomainEventsPublisher.GetInstancia().PublishEvents(changes);
+                await DomainEventsPublisher.GetInstancia().PublishEvents(changes);
                 account.AcceptChanges();
             }
                 

--- a/EjemploEventSourcing/Application/Interactors/CreateAccount/ICreateAccountInteractor.cs
+++ b/EjemploEventSourcing/Application/Interactors/CreateAccount/ICreateAccountInteractor.cs
@@ -5,6 +5,6 @@ namespace EjemploEventSourcing.Application.Interactors.CreateAccount
 {
     public interface ICreateAccountInteractor
     {
-        void Execute(string id);
+        Task Execute(string id);
     }
 }

--- a/EjemploEventSourcing/Application/Interactors/DepositAmount/DepositAmountInteractor.cs
+++ b/EjemploEventSourcing/Application/Interactors/DepositAmount/DepositAmountInteractor.cs
@@ -27,7 +27,7 @@ namespace EjemploEventSourcing.Application.Interactors.DepositAmount
                 if (account.HasChanges())
                 {
                     var changes = account.GetChanges();
-                    DomainEventsPublisher.GetInstancia().PublishEvents(changes);
+                    await DomainEventsPublisher.GetInstancia().PublishEvents(changes);
                     account.AcceptChanges();
                 }
             }


### PR DESCRIPTION
## Summary

Makes the event persistence/publishing path await asynchronous operations before returning HTTP responses.

## Changes

- Converted create-account interactor execution to return Task.
- Made DomainEventsPublisher publish methods asynchronous.
- Awaited subscriber ManageEvent calls during event publication.
- Awaited create-account and deposit-amount interactor execution from controllers.

## Why

The API could return success before event persistence/publication completed. The build also reported async warnings for unawaited calls and async methods without await.

## Scope

- [ ] Docs
- [x] API
- [x] Domain / Events
- [ ] Persistence
- [ ] Messaging
- [ ] Infra / Config

## Testing

- [ ] Manual
- [ ] Unit tests
- [x] Not applicable

Validation run:

- dotnet build EjemploEventSourcing.sln

Result: build succeeded with 4 remaining warnings unrelated to await handling.

## Notes

Remaining warnings are CA2200 for throw ex/throw e and CS8981 for the existing lowercase EF migration class name.