### PR TITLE
test(domain): add account aggregate tests

### DIFF
--- a/EjemploEventSourcing.Tests/Domain/AccountTests.cs
+++ b/EjemploEventSourcing.Tests/Domain/AccountTests.cs
@@ -1,0 +1,105 @@
+using EjemploEventSourcing.Application.Domain.Entities;
+using EjemploEventSourcing.Application.Domain.Events;
+using EjemploEventSourcing.Application.Domain.Events.Interfaces;
+using Xunit;
+
+namespace EjemploEventSourcing.Tests.Domain;
+
+public class AccountTests
+{
+    [Fact]
+    public void CreateAccount_RecordsAccountCreatedEvent()
+    {
+        var account = Account.CreateAccount("account-1");
+
+        var changes = account.GetChanges();
+        var @event = Assert.Single(changes.Events);
+        var data = Assert.IsType<DataAccountCreatedEvent>(@event.GetData());
+
+        Assert.True(account.HasChanges());
+        Assert.Equal("account-1", changes.AggregateInfo.AggregateId);
+        Assert.Equal(0, changes.AggregateInfo.AggregateBaseVersion);
+        Assert.Equal(1, changes.AggregateInfo.AggregateActualVersion);
+        Assert.Equal(nameof(Account), changes.AggregateInfo.AggregateType);
+        Assert.Equal(EventTypes.AccountCreated, @event.GetEventType());
+        Assert.Equal("account-1", data.AccountId);
+        Assert.Equal(0m, data.Balance);
+    }
+
+    [Fact]
+    public void DepositAmount_RecordsAmountDepositedEventWithNextVersion()
+    {
+        var account = Account.CreateEmptyAccount("account-1");
+        account.BuildAggregate(BuildConstructor("account-1", 1, AccountCreated("account-1")));
+
+        account.DepositAmount(25m);
+
+        var changes = account.GetChanges();
+        var @event = Assert.Single(changes.Events);
+        var data = Assert.IsType<DataAmountDepositedEvent>(@event.GetData());
+
+        Assert.True(account.HasChanges());
+        Assert.Equal(1, changes.AggregateInfo.AggregateBaseVersion);
+        Assert.Equal(2, changes.AggregateInfo.AggregateActualVersion);
+        Assert.Equal(EventTypes.AmountDeposited, @event.GetEventType());
+        Assert.Equal("account-1", data.AccountId);
+        Assert.Equal(25m, data.AmountDeposited);
+    }
+
+    [Fact]
+    public void BuildAggregate_ReplaysStoredEvents()
+    {
+        var account = Account.CreateEmptyAccount("account-1");
+
+        account.BuildAggregate(BuildConstructor(
+            "account-1",
+            3,
+            AccountCreated("account-1"),
+            AmountDeposited("account-1", 50m),
+            AmountDeposited("account-1", 75m)));
+
+        Assert.False(account.HasChanges());
+        Assert.Equal("account-1", account.Id);
+        Assert.Equal(125m, account.Balance);
+    }
+
+    [Fact]
+    public void BuildAggregate_ThrowsWhenBaseVersionDoesNotMatchReplayedEvents()
+    {
+        var account = Account.CreateEmptyAccount("account-1");
+        var constructor = BuildConstructor("account-1", 2, AccountCreated("account-1"));
+
+        Assert.Throws<InvalidOperationException>(() => account.BuildAggregate(constructor));
+    }
+
+    private static AggregateInfoConstructor BuildConstructor(
+        string aggregateId,
+        int baseVersion,
+        params IEvent[] events)
+    {
+        return new AggregateInfoConstructor
+        {
+            AggregateId = aggregateId,
+            AggregateBaseVersion = baseVersion,
+            Events = events
+        };
+    }
+
+    private static AccountCreatedEvent AccountCreated(string accountId)
+    {
+        return new AccountCreatedEvent(new DataAccountCreatedEvent
+        {
+            AccountId = accountId,
+            Balance = 0m
+        });
+    }
+
+    private static AmountDepositedEvent AmountDeposited(string accountId, decimal amount)
+    {
+        return new AmountDepositedEvent(new DataAmountDepositedEvent
+        {
+            AccountId = accountId,
+            AmountDeposited = amount
+        });
+    }
+}

--- a/EjemploEventSourcing.Tests/EjemploEventSourcing.Tests.csproj
+++ b/EjemploEventSourcing.Tests/EjemploEventSourcing.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EjemploEventSourcing\EjemploEventSourcing.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/EjemploEventSourcing.sln
+++ b/EjemploEventSourcing.sln
@@ -18,6 +18,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AmountDepositedConsumer", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "Common\Common.csproj", "{DF72788A-A29C-4627-9196-EAA2CBDD6A85}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EjemploEventSourcing.Tests", "EjemploEventSourcing.Tests\EjemploEventSourcing.Tests.csproj", "{7F633242-124D-4713-AA65-F4690B0C26AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,6 +58,10 @@ Global
 		{DF72788A-A29C-4627-9196-EAA2CBDD6A85}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF72788A-A29C-4627-9196-EAA2CBDD6A85}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF72788A-A29C-4627-9196-EAA2CBDD6A85}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F633242-124D-4713-AA65-F4690B0C26AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F633242-124D-4713-AA65-F4690B0C26AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F633242-124D-4713-AA65-F4690B0C26AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F633242-124D-4713-AA65-F4690B0C26AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Adds the first unit test project and covers the account aggregate Event Sourcing behavior.

## Changes

- Added an xUnit test project targeting net8.0.
- Added tests for account creation event recording.
- Added tests for deposit event recording and aggregate replay.
- Added a version mismatch test for aggregate reconstruction.

## Why

The repository had no unit tests. These tests create a fast safety net around the domain model before adding infrastructure or integration-level changes.

## Scope

- [ ] Docs
- [ ] API
- [x] Domain / Events
- [ ] Persistence
- [ ] Messaging
- [ ] Infra / Config

## Testing

- [ ] Manual
- [x] Unit tests
- [ ] Not applicable

Validation run:

- dotnet test EjemploEventSourcing.sln
- dotnet build EjemploEventSourcing.sln

Result: 4 tests passed. Full solution build succeeded with the existing EF migration naming warnings.

## Notes

These tests intentionally avoid PostgreSQL and RabbitMQ. Integration tests can be added later once the local dependency setup is reproducible.