### PR TITLE
test(events): cover event store mapping

### DIFF
--- a/EjemploEventSourcing.Tests/EjemploEventSourcing.Tests.csproj
+++ b/EjemploEventSourcing.Tests/EjemploEventSourcing.Tests.csproj
@@ -17,6 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\EjemploEventSourcing.Infrastructure\EjemploEventSourcing.Infrastructure.csproj" />
     <ProjectReference Include="..\EjemploEventSourcing\EjemploEventSourcing.Application.csproj" />
   </ItemGroup>
 

--- a/EjemploEventSourcing.Tests/Services/EventStoreMappingTests.cs
+++ b/EjemploEventSourcing.Tests/Services/EventStoreMappingTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using EjemploEventSourcing.Application.Domain.Entities;
+using EjemploEventSourcing.Application.Domain.Events;
+using EjemploEventSourcing.Application.Domain.Events.Interfaces;
+using EjemploEventSourcing.Application.DTO;
+using EjemploEventSourcing.Application.Services;
+using EjemploEventSourcing.Infrastructure.Repositorios;
+using EjemploEventSourcing.Infrastructure.services;
+using EjemploEventSourcing.Infrastructure.Services;
+using Xunit;
+
+namespace EjemploEventSourcing.Tests.Services;
+
+public class EventStoreMappingTests
+{
+    [Fact]
+    public void EventMapper_MapsDomainEventToStoredDto()
+    {
+        var aggregateInfo = new AggregateInfo
+        {
+            AggregateId = "account-1",
+            AggregateBaseVersion = 1,
+            AggregateActualVersion = 2,
+            AggregateType = nameof(Account)
+        };
+        var domainEvent = AmountDeposited("account-1", 25m);
+
+        var dto = EventStoreMapper.EventMapper(aggregateInfo, 2, domainEvent);
+        var data = JsonSerializer.Deserialize<DataAmountDepositedEvent>(dto.AggregateData);
+
+        Assert.Equal("account-1", dto.AggregateId);
+        Assert.Equal(1, dto.AggregateBaseVersion);
+        Assert.Equal(2, dto.AggregateActualVersion);
+        Assert.Equal(nameof(Account), dto.AggregateType);
+        Assert.Equal((int)EventTypes.AmountDeposited, dto.EventType);
+        Assert.Equal(2, dto.EventVersion);
+        Assert.Equal(domainEvent.GetDateItHappened(), dto.CreationDate);
+        Assert.NotNull(data);
+        Assert.Equal("account-1", data.AccountId);
+        Assert.Equal(25m, data.AmountDeposited);
+    }
+
+    [Fact]
+    public void MapperFromEventToEventStoreDTO_MapsStoredDtoToRepositoryEvent()
+    {
+        var creationDate = new DateTime(2026, 4, 25, 12, 0, 0);
+        var dto = new EventStoredDTO
+        {
+            AggregateId = "account-1",
+            AggregateData = """{"AccountId":"account-1","Balance":0}""",
+            CreationDate = creationDate,
+            EventType = (int)EventTypes.AccountCreated,
+            EventVersion = 1
+        };
+
+        var repositoryEvent = EventStoreDtoMapper.MapperFromEventToEventStoreDTO(dto);
+
+        Assert.Equal("account-1", repositoryEvent.AggregateId);
+        Assert.Equal(dto.AggregateData, repositoryEvent.AggregateData);
+        Assert.Equal(creationDate, repositoryEvent.DateTimeCreate);
+        Assert.Equal(EventTypes.AccountCreated, repositoryEvent.EventType);
+        Assert.Equal(0, repositoryEvent.AggregateVersion);
+        Assert.Equal(string.Empty, repositoryEvent.MetaData);
+    }
+
+    [Fact]
+    public void EventMapperRepositoryToIEvent_MapsAccountCreatedRepositoryEventToDomainEvent()
+    {
+        var repositoryEvent = new Event
+        {
+            AggregateId = "account-1",
+            AggregateData = """{"AccountId":"account-1","Balance":0}""",
+            EventType = EventTypes.AccountCreated
+        };
+
+        var domainEvent = EventsMapper.EventMapperRepositoryToIEvent(repositoryEvent);
+        var data = Assert.IsType<DataAccountCreatedEvent>(domainEvent.GetData());
+
+        Assert.Equal(EventTypes.AccountCreated, domainEvent.GetEventType());
+        Assert.Equal("account-1", data.AccountId);
+        Assert.Equal(0m, data.Balance);
+    }
+
+    [Fact]
+    public void EventMapperRepositoryToIEvent_MapsAmountDepositedRepositoryEventToDomainEvent()
+    {
+        var repositoryEvent = new Event
+        {
+            AggregateId = "account-1",
+            AggregateData = """{"AccountId":"account-1","AmountDeposited":25}""",
+            EventType = EventTypes.AmountDeposited
+        };
+
+        var domainEvent = EventsMapper.EventMapperRepositoryToIEvent(repositoryEvent);
+        var data = Assert.IsType<DataAmountDepositedEvent>(domainEvent.GetData());
+
+        Assert.Equal(EventTypes.AmountDeposited, domainEvent.GetEventType());
+        Assert.Equal("account-1", data.AccountId);
+        Assert.Equal(25m, data.AmountDeposited);
+    }
+
+    [Fact]
+    public void EventsMapperRepositoryToIEvents_MapsRepositoryEventSequence()
+    {
+        var repositoryEvents = new[]
+        {
+            new Event
+            {
+                AggregateData = """{"AccountId":"account-1","Balance":0}""",
+                EventType = EventTypes.AccountCreated
+            },
+            new Event
+            {
+                AggregateData = """{"AccountId":"account-1","AmountDeposited":25}""",
+                EventType = EventTypes.AmountDeposited
+            }
+        };
+
+        var domainEvents = EventsMapper.EventsMapperRepositoryToIEvents(repositoryEvents).ToList();
+
+        Assert.Collection(
+            domainEvents,
+            e => Assert.Equal(EventTypes.AccountCreated, e.GetEventType()),
+            e => Assert.Equal(EventTypes.AmountDeposited, e.GetEventType()));
+    }
+
+    [Fact]
+    public void EventMapperRepositoryToIEvent_ThrowsForUnknownEventType()
+    {
+        var repositoryEvent = new Event
+        {
+            AggregateData = "{}",
+            EventType = (EventTypes)999
+        };
+
+        Assert.Throws<InvalidOperationException>(() => EventsMapper.EventMapperRepositoryToIEvent(repositoryEvent));
+    }
+
+    private static AmountDepositedEvent AmountDeposited(string accountId, decimal amount)
+    {
+        return new AmountDepositedEvent(new DataAmountDepositedEvent
+        {
+            AccountId = accountId,
+            AmountDeposited = amount
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Adds unit coverage for the event mapping path between domain events, stored DTOs, repository entities, and replayable domain events.

## Changes

- Added infrastructure reference to the test project.
- Covered EventStoreMapper domain event to EventStoredDTO mapping.
- Covered EventStoreDtoMapper EventStoredDTO to repository Event mapping.
- Covered EventsMapper repository Event to domain event mapping for account-created and amount-deposited events.
- Covered sequence mapping and unknown event type failure behavior.

## Why

Event serialization and replay mapping are central to the Event Sourcing example. These tests protect event type, payload, aggregate metadata, and replay conversion behavior before deeper persistence changes.

## Scope

- [ ] Docs
- [ ] API
- [x] Domain / Events
- [x] Persistence
- [ ] Messaging
- [ ] Infra / Config

## Testing

- [ ] Manual
- [x] Unit tests
- [ ] Not applicable

Validation run:

- dotnet test EjemploEventSourcing.sln
- dotnet build EjemploEventSourcing.sln

Result: 10 tests passed. Full solution build succeeded.

## Notes

The DTO-to-repository mapper currently leaves AggregateVersion at its default value; EventStoreService sets it later during commit. This PR documents current behavior with tests and does not change production code.