### PR TITLE
fix(exceptions): preserve stack traces

### DIFF
--- a/EjemploEventSourcing/Application/Interactors/DepositAmount/DepositAmountInteractor.cs
+++ b/EjemploEventSourcing/Application/Interactors/DepositAmount/DepositAmountInteractor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using EjemploEventSourcing.Application.Domain.Entities;
 using EjemploEventSourcing.Application.Domain.Events.Interfaces;
 using EjemploEventSourcing.Application.Gateways;
@@ -21,23 +20,16 @@ namespace EjemploEventSourcing.Application.Interactors.DepositAmount
 
         public async Task Execute(string accountId, decimal depositAmount)
         {
-            try
-            {
-                var constructor = await _getAccountById.GetAccountById(accountId);
-                var account = Account.CreateEmptyAccount(constructor.AggregateId);
-                account.BuildAggregate(constructor);
-                account.DepositAmount(depositAmount);
+            var constructor = await _getAccountById.GetAccountById(accountId);
+            var account = Account.CreateEmptyAccount(constructor.AggregateId);
+            account.BuildAggregate(constructor);
+            account.DepositAmount(depositAmount);
 
-                if (account.HasChanges())
-                {
-                    var changes = account.GetChanges();
-                    await _publisher.PublishEvents(changes);
-                    account.AcceptChanges();
-                }
-            }
-            catch(Exception e)
+            if (account.HasChanges())
             {
-                throw e;
+                var changes = account.GetChanges();
+                await _publisher.PublishEvents(changes);
+                account.AcceptChanges();
             }
         }
     }

--- a/EjemploEventSourcing/Application/Services/DepositAmountSuscriber.cs
+++ b/EjemploEventSourcing/Application/Services/DepositAmountSuscriber.cs
@@ -29,9 +29,9 @@ namespace EjemploEventSourcing.Application.Services
                 await _service.Save(dto);
                 _presenter.PublishAmountDeposited(dto.AggregateId, dto.AggregateData);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
-                throw ex;
+                throw;
             }
         }
 


### PR DESCRIPTION
## Summary

Preserves original exception stack traces in the deposit flow.

## Changes

- Removed a try/catch in DepositAmountInteractor that only rethrew the same exception.
- Changed DepositAmountSuscriber to rethrow with throw instead of throw ex.

## Why

Rethrowing captured exceptions with throw ex/throw e resets stack trace information and produced CA2200 warnings. Preserving stack traces makes failures easier to debug.

## Scope

- [ ] Docs
- [ ] API
- [ ] Domain / Events
- [ ] Persistence
- [ ] Messaging
- [ ] Infra / Config

## Testing

- [ ] Manual
- [x] Unit tests
- [ ] Not applicable

Validation run:

- dotnet test EjemploEventSourcing.sln
- dotnet build EjemploEventSourcing.sln

Result: 14 tests passed. Full solution build succeeded with 0 warnings and 0 errors.

## Notes

This PR only changes exception rethrow behavior. It does not add new error handling or presenter behavior.