### PR TITLE
fix(infra): use scoped event store db context

### DIFF
--- a/EjemploEventSourcing.IoC/DependencyContainer.cs
+++ b/EjemploEventSourcing.IoC/DependencyContainer.cs
@@ -36,8 +36,7 @@ namespace EjemploEventSourcing.IoC
             services.AddSingleton<IConnectionFactory>(rabbitFactory);
 
             services.AddDbContext<EventStoreDBContext>(opt =>
-                opt.UseNpgsql(configuration.GetConnectionString("MyWebApiConnection")),
-                ServiceLifetime.Singleton);
+                opt.UseNpgsql(configuration.GetConnectionString("MyWebApiConnection")));
 
             services.AddScoped<IGetAccountByIdInteractor, GetAccountByIdInteractor>();
             services.AddScoped<IGetAccountsInteractor, GetAccountsInteractor>();


### PR DESCRIPTION
## Summary

Uses the default scoped lifetime for the EF Core event store DbContext.

## Changes

- Removed the explicit Singleton lifetime from EventStoreDBContext registration.
- Let AddDbContext use its default scoped lifetime.

## Why

DbContext instances are not thread-safe and should not be shared across requests. Scoped registration aligns the event store context with ASP.NET Core request lifetimes.

## Scope

- [ ] Docs
- [ ] API
- [ ] Domain / Events
- [x] Persistence
- [ ] Messaging
- [x] Infra / Config

## Testing

- [ ] Manual
- [x] Unit tests
- [ ] Not applicable

Validation run:

- dotnet test EjemploEventSourcing.sln
- dotnet build EjemploEventSourcing.sln

Result: 14 tests passed. Full solution build succeeded with 0 warnings and 0 errors.

## Notes

This PR only changes DI lifetime. It does not change event store persistence behavior.