### PR TITLE
chore(dev): add local dependency compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Ejemplo Event Sourcing
+
+Ejemplo de Event Sourcing con ASP.NET Core, PostgreSQL como event store y RabbitMQ para publicar eventos.
+
+## Requisitos
+
+- .NET SDK 8
+- Docker
+
+## Dependencias locales
+
+Levantar PostgreSQL y RabbitMQ:
+
+```bash
+docker compose up -d
+```
+
+Servicios expuestos:
+
+- PostgreSQL: `localhost:5432`
+- RabbitMQ: `localhost:5672`
+- RabbitMQ Management: <http://localhost:15672>
+
+Credenciales RabbitMQ:
+
+- usuario: `guest`
+- password: `nimda`
+- vhost: `example-vhost`
+
+La configuración coincide con `EjemploEventSourcing.API/appsettings.json`.
+
+## Base de datos
+
+Aplicar migraciones:
+
+```bash
+dotnet ef database update \
+  --project EjemploEventSourcing.Infrastructure \
+  --startup-project EjemploEventSourcing.API
+```
+
+## Ejecutar
+
+```bash
+dotnet run --project EjemploEventSourcing.API
+```
+
+Swagger queda disponible en la URL configurada por ASP.NET Core para el proyecto.
+
+## Validar
+
+```bash
+dotnet test EjemploEventSourcing.sln
+dotnet build EjemploEventSourcing.sln
+```
+
+## Apagar dependencias
+
+```bash
+docker compose down
+```
+
+Para borrar también los datos locales de PostgreSQL:
+
+```bash
+docker compose down -v
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: ejemplo-event-sourcing-postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: EventSourcing
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d EventSourcing"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  rabbitmq:
+    build:
+      context: ./script/Docker/RabbitMQ
+    container_name: ejemplo-event-sourcing-rabbitmq
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres-data:

--- a/script/Docker/RabbitMQ/Dockerfile
+++ b/script/Docker/RabbitMQ/Dockerfile
@@ -1,6 +1,6 @@
 FROM rabbitmq:3.8.3-management-alpine
 
-MAINTAINER <gustavoarielms@gmail.com>
+LABEL maintainer="gustavoarielms@gmail.com"
 
 COPY rabbitmq.conf /etc/rabbitmq/
 COPY definitions.json /etc/rabbitmq/


### PR DESCRIPTION
## Summary

Adds a local Docker Compose setup for the PostgreSQL event store and RabbitMQ broker.

## Changes

- Added docker-compose.yml with PostgreSQL and RabbitMQ services.
- Reused the existing RabbitMQ Docker build context and definitions.
- Added README instructions for local dependencies, migrations, API execution, validation, and shutdown.
- Replaced deprecated MAINTAINER in the RabbitMQ Dockerfile with a maintainer label.

## Why

Functional testing currently requires manually configured PostgreSQL and RabbitMQ. This gives contributors a repeatable local setup aligned with appsettings.json.

## Scope

- [x] Docs
- [ ] API
- [ ] Domain / Events
- [x] Persistence
- [x] Messaging
- [x] Infra / Config

## Testing

- [x] Manual
- [x] Unit tests
- [ ] Not applicable

Validation run:

- docker compose config
- docker compose up -d --build
- docker compose ps
- docker compose down -v
- dotnet test EjemploEventSourcing.sln
- dotnet build EjemploEventSourcing.sln

Result: compose configuration is valid, services started successfully, 14 tests passed, and full solution build succeeded with 0 warnings and 0 errors.

## Notes

This PR does not add integration tests or automate EF migration execution. It only adds the local dependency setup and usage documentation.