### PR TITLE
fix(dev): make local smoke flow runnable

### DIFF
--- a/EjemploEventSourcing.API/EjemploEventSourcing.API.csproj
+++ b/EjemploEventSourcing.API/EjemploEventSourcing.API.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
   </ItemGroup>

--- a/EjemploEventSourcing.API/appsettings.json
+++ b/EjemploEventSourcing.API/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "MyWebApiConnection": "User ID =postgres;Password=postgres;Server=localhost;Port=5432;Database=EventSourcing;Integrated Security=true;Pooling=true;"
+    "MyWebApiConnection": "User ID=postgres;Password=postgres;Server=localhost;Port=5432;Database=EventSourcing;Pooling=true;"
   },
   "RabbitMQ": {
     "UserName": "guest",

--- a/EjemploEventSourcing.Tests/Domain/AccountTests.cs
+++ b/EjemploEventSourcing.Tests/Domain/AccountTests.cs
@@ -22,6 +22,7 @@ public class AccountTests
         Assert.Equal(1, changes.AggregateInfo.AggregateActualVersion);
         Assert.Equal(nameof(Account), changes.AggregateInfo.AggregateType);
         Assert.Equal(EventTypes.AccountCreated, @event.GetEventType());
+        Assert.Equal(DateTimeKind.Utc, @event.GetDateItHappened().Kind);
         Assert.Equal("account-1", data.AccountId);
         Assert.Equal(0m, data.Balance);
     }
@@ -42,6 +43,7 @@ public class AccountTests
         Assert.Equal(1, changes.AggregateInfo.AggregateBaseVersion);
         Assert.Equal(2, changes.AggregateInfo.AggregateActualVersion);
         Assert.Equal(EventTypes.AmountDeposited, @event.GetEventType());
+        Assert.Equal(DateTimeKind.Utc, @event.GetDateItHappened().Kind);
         Assert.Equal("account-1", data.AccountId);
         Assert.Equal(25m, data.AmountDeposited);
     }

--- a/EjemploEventSourcing/Application/Domain/Events/AccountCreatedEvent.cs
+++ b/EjemploEventSourcing/Application/Domain/Events/AccountCreatedEvent.cs
@@ -11,7 +11,7 @@ namespace EjemploEventSourcing.Application.Domain.Events
 
         public AccountCreatedEvent(DataAccountCreatedEvent data)
         {
-            _dateItHappened = DateTime.Now;
+            _dateItHappened = DateTime.UtcNow;
             _data = data;
         }
 

--- a/EjemploEventSourcing/Application/Domain/Events/AmountDepositedEvent.cs
+++ b/EjemploEventSourcing/Application/Domain/Events/AmountDepositedEvent.cs
@@ -10,7 +10,7 @@ namespace EjemploEventSourcing.Application.Domain.Events
 
         public AmountDepositedEvent(DataAmountDepositedEvent data)
         {
-            _dateItHappened = DateTime.Now;
+            _dateItHappened = DateTime.UtcNow;
             _data = data;
         }
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,43 @@ dotnet ef database update \
   --startup-project EjemploEventSourcing.API
 ```
 
+Si `dotnet ef` no está instalado:
+
+```bash
+dotnet tool install --global dotnet-ef --version 8.0.8
+```
+
 ## Ejecutar
 
 ```bash
-dotnet run --project EjemploEventSourcing.API
+dotnet run --no-launch-profile \
+  --project EjemploEventSourcing.API \
+  --urls http://127.0.0.1:5110
 ```
 
-Swagger queda disponible en la URL configurada por ASP.NET Core para el proyecto.
+Swagger queda disponible en <http://127.0.0.1:5110>.
+
+## Smoke test
+
+Crear cuenta:
+
+```bash
+curl -X POST http://127.0.0.1:5110/CreateAccount
+```
+
+Depositar en la cuenta creada:
+
+```bash
+curl -X POST http://127.0.0.1:5110/DepositAmount \
+  -H "Content-Type: application/json" \
+  -d '{"accountId":"ACCOUNT_ID","depositAmount":100}'
+```
+
+Consultar la cuenta:
+
+```bash
+curl http://127.0.0.1:5110/GetAccountById/ACCOUNT_ID
+```
 
 ## Validar
 


### PR DESCRIPTION
## Summary

Fixes issues found while running the local account smoke flow against Docker Compose dependencies.

## Changes

- Added Microsoft.EntityFrameworkCore.Design to the API startup project so dotnet ef can run with that startup project.
- Removed unsupported Integrated Security from the PostgreSQL connection string for Npgsql 8.
- Changed domain event timestamps from local time to UTC for PostgreSQL timestamp with time zone compatibility.
- Added unit assertions that account events use UTC timestamps.
- Updated README with dotnet-ef installation guidance, HTTP run command, and smoke-test curl examples.

## Why

The local smoke test exposed three blockers: migrations could not run, the connection string failed under Npgsql 8, and event persistence failed because local DateTime values cannot be written to PostgreSQL timestamp with time zone columns.

## Scope

- [x] Docs
- [ ] API
- [x] Domain / Events
- [x] Persistence
- [ ] Messaging
- [x] Infra / Config

## Testing

- [x] Manual
- [x] Unit tests
- [ ] Not applicable

Validation run:

- docker compose up -d --build
- /tmp/dotnet-tools/dotnet-ef database update --project EjemploEventSourcing.Infrastructure --startup-project EjemploEventSourcing.API
- dotnet run --no-launch-profile --project EjemploEventSourcing.API --urls http://127.0.0.1:5110
- curl POST /CreateAccount
- curl POST /DepositAmount
- curl GET /GetAccountById/{id}
- docker compose exec -T rabbitmq rabbitmqctl list_queues -p example-vhost name messages_ready messages_unacknowledged
- docker compose down -v
- dotnet test EjemploEventSourcing.sln
- dotnet build EjemploEventSourcing.sln

Result: migrations applied, create/deposit/get returned balance 100, RabbitMQ queues received account/deposit/events messages, 14 tests passed, and full solution build succeeded with 0 warnings and 0 errors.

## Notes

Port 5000 was occupied by macOS Control Center/AirTunes on this machine, so the documented smoke command uses 5110.