### PR TITLE
chore: upgrade to dotnet 10

### DIFF
--- a/AccountCreatedConsumer/AccountCreatedConsumer.csproj
+++ b/AccountCreatedConsumer/AccountCreatedConsumer.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AccountCreatedConsumer/Program.cs
+++ b/AccountCreatedConsumer/Program.cs
@@ -4,12 +4,13 @@ using RabbitMQ.Client.Events;
 using System;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace AccountCreatedConsumer
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             var rabbitFactory = new ConnectionFactory
             {
@@ -19,20 +20,21 @@ namespace AccountCreatedConsumer
                 HostName = "localhost"
             };
 
-            using var connection = rabbitFactory.CreateConnection();
-            using var channel = connection.CreateModel();
+            await using var connection = await rabbitFactory.CreateConnectionAsync();
+            await using var channel = await connection.CreateChannelAsync();
 
-            var consumer = new EventingBasicConsumer(channel);
-            consumer.Received += (model, ea) =>
+            var consumer = new AsyncEventingBasicConsumer(channel);
+            consumer.ReceivedAsync += (model, ea) =>
             {
                 var body = ea.Body.ToArray();
                 var message = Encoding.UTF8.GetString(body);
                 var response = JsonSerializer.Deserialize<ResponseDTO>(message);
                 Console.WriteLine($" [x] Received {response.AggregateId}, {response.AggregateData}");
+                return Task.CompletedTask;
             };
-            channel.BasicConsume(queue: "AccountCreated",
-                                 autoAck: false,
-                                 consumer: consumer);
+            await channel.BasicConsumeAsync(queue: "AccountCreated",
+                                            autoAck: false,
+                                            consumer: consumer);
 
             Console.ReadLine();
         }

--- a/AllEventsConsumer/AllEventsConsumer.csproj
+++ b/AllEventsConsumer/AllEventsConsumer.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AllEventsConsumer/Program.cs
+++ b/AllEventsConsumer/Program.cs
@@ -5,12 +5,13 @@ using System;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace AllEventsConsumer
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             var rabbitFactory = new ConnectionFactory
             {
@@ -22,11 +23,11 @@ namespace AllEventsConsumer
 
             var httpClient = new HttpClient();
 
-            using var connection = rabbitFactory.CreateConnection();
-            using var channel = connection.CreateModel();
+            await using var connection = await rabbitFactory.CreateConnectionAsync();
+            await using var channel = await connection.CreateChannelAsync();
 
-            var consumer = new EventingBasicConsumer(channel);
-            consumer.Received += async (model, ea) =>
+            var consumer = new AsyncEventingBasicConsumer(channel);
+            consumer.ReceivedAsync += async (model, ea) =>
             {
                 var body = ea.Body.ToArray();
                 var message = Encoding.UTF8.GetString(body);
@@ -40,9 +41,9 @@ namespace AllEventsConsumer
                 }
 
             };
-            channel.BasicConsume(queue: "Events",
-                                 autoAck: true,
-                                 consumer: consumer);
+            await channel.BasicConsumeAsync(queue: "Events",
+                                            autoAck: true,
+                                            consumer: consumer);
 
             Console.ReadLine();
         }

--- a/AmountDepositedConsumer/AmountDepositedConsumer.csproj
+++ b/AmountDepositedConsumer/AmountDepositedConsumer.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AmountDepositedConsumer/Program.cs
+++ b/AmountDepositedConsumer/Program.cs
@@ -4,12 +4,13 @@ using RabbitMQ.Client.Events;
 using System;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace AmountDepositedConsumer
 {
     class Program
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             var rabbitFactory = new ConnectionFactory
             {
@@ -19,20 +20,21 @@ namespace AmountDepositedConsumer
                 HostName = "localhost"
             };
 
-            using var connection = rabbitFactory.CreateConnection();
-            using var channel = connection.CreateModel();
+            await using var connection = await rabbitFactory.CreateConnectionAsync();
+            await using var channel = await connection.CreateChannelAsync();
 
-            var consumer = new EventingBasicConsumer(channel);
-            consumer.Received += (model, ea) =>
+            var consumer = new AsyncEventingBasicConsumer(channel);
+            consumer.ReceivedAsync += (model, ea) =>
             {
                 var body = ea.Body.ToArray();
                 var message = Encoding.UTF8.GetString(body);
                 var response = JsonSerializer.Deserialize<ResponseDTO>(message);
                 Console.WriteLine($" [x] Received {response.AggregateId}, {response.AggregateData}");
+                return Task.CompletedTask;
             };
-            channel.BasicConsume(queue: "AmountDeposited",
-                                 autoAck: true,
-                                 consumer: consumer);
+            await channel.BasicConsumeAsync(queue: "AmountDeposited",
+                                            autoAck: true,
+                                            consumer: consumer);
 
             Console.ReadLine();
         }

--- a/Common/Common.csproj
+++ b/Common/Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/EjemploEventSourcing.API/EjemploEventSourcing.API.csproj
+++ b/EjemploEventSourcing.API/EjemploEventSourcing.API.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <UserSecretsId>7162a66d-a70c-4ef7-82b0-d7d4156d1fba</UserSecretsId>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EjemploEventSourcing.API/Presenters/AccountCreatedPresenter.cs
+++ b/EjemploEventSourcing.API/Presenters/AccountCreatedPresenter.cs
@@ -3,6 +3,7 @@ using EjemploEventSourcing.Application.IPresenters;
 using RabbitMQ.Client;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace EjemploEventSourcing.Presenters
 {
@@ -18,24 +19,34 @@ namespace EjemploEventSourcing.Presenters
 
         public void PublishAccountCreated(string aggregateId, string aggregateData)
         {
-            using var connection = _rabbitFactory.CreateConnection();
-            using var channel = connection.CreateModel();
+            PublishAccountCreatedAsync(aggregateId, aggregateData).GetAwaiter().GetResult();
+        }
+
+        private async Task PublishAccountCreatedAsync(string aggregateId, string aggregateData)
+        {
+            await using var connection = await _rabbitFactory.CreateConnectionAsync();
+            await using var channel = await connection.CreateChannelAsync();
             var response = new ResponseDTO
             {
                 AggregateId = aggregateId,
                 AggregateData = aggregateData
             };
             var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(response));
-            channel.BasicPublish(exchange: "example-exchange", routingKey: "event.AccountCreated", basicProperties: null, body: body);
+            await channel.BasicPublishAsync(exchange: "example-exchange", routingKey: "event.AccountCreated", body: body);
         }
 
         public void PublishErrorCreatingAccount(string errorMessage)
         {
-            using var connection = _rabbitFactory.CreateConnection();
-            using var channel = connection.CreateModel();
+            PublishErrorCreatingAccountAsync(errorMessage).GetAwaiter().GetResult();
+        }
+
+        private async Task PublishErrorCreatingAccountAsync(string errorMessage)
+        {
+            await using var connection = await _rabbitFactory.CreateConnectionAsync();
+            await using var channel = await connection.CreateChannelAsync();
             var body = Encoding.UTF8.GetBytes(errorMessage);
 
-            channel.BasicPublish(exchange: "example-exchange", routingKey: "error.AccountCreated", basicProperties: null, body: body);
+            await channel.BasicPublishAsync(exchange: "example-exchange", routingKey: "error.AccountCreated", body: body);
         }
     }
 }

--- a/EjemploEventSourcing.API/Presenters/AmountDepositedPresenter.cs
+++ b/EjemploEventSourcing.API/Presenters/AmountDepositedPresenter.cs
@@ -3,6 +3,7 @@ using EjemploEventSourcing.Application.IPresenters;
 using RabbitMQ.Client;
 using System.Text;
 using System.Text.Json;
+using System.Threading.Tasks;
 
 namespace EjemploEventSourcing.Presenters
 {
@@ -18,24 +19,34 @@ namespace EjemploEventSourcing.Presenters
 
         public void PublishAmountDeposited(string aggregateId, string aggregateData)
         {
-            using var connection = _rabbitFactory.CreateConnection();
-            using var channel = connection.CreateModel();
+            PublishAmountDepositedAsync(aggregateId, aggregateData).GetAwaiter().GetResult();
+        }
+
+        private async Task PublishAmountDepositedAsync(string aggregateId, string aggregateData)
+        {
+            await using var connection = await _rabbitFactory.CreateConnectionAsync();
+            await using var channel = await connection.CreateChannelAsync();
             var response = new ResponseDTO
             {
                 AggregateId = aggregateId,
                 AggregateData = aggregateData
             };
             var body = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(response));
-            channel.BasicPublish(exchange: "example-exchange", routingKey: "event.AmountDeposited", basicProperties: null, body: body);
+            await channel.BasicPublishAsync(exchange: "example-exchange", routingKey: "event.AmountDeposited", body: body);
         }
 
         public void PublishErrorDepositingAmount(string errorMessage)
         {
-            using var connection = _rabbitFactory.CreateConnection();
-            using var channel = connection.CreateModel();
+            PublishErrorDepositingAmountAsync(errorMessage).GetAwaiter().GetResult();
+        }
+
+        private async Task PublishErrorDepositingAmountAsync(string errorMessage)
+        {
+            await using var connection = await _rabbitFactory.CreateConnectionAsync();
+            await using var channel = await connection.CreateChannelAsync();
             var body = Encoding.UTF8.GetBytes(errorMessage);
 
-            channel.BasicPublish(exchange: "example-exchange", routingKey: "error.AmountDeposited", basicProperties: null, body: body);
+            await channel.BasicPublishAsync(exchange: "example-exchange", routingKey: "error.AmountDeposited", body: body);
         }
     }
 }

--- a/EjemploEventSourcing.Infrastructure/EjemploEventSourcing.Infrastructure.csproj
+++ b/EjemploEventSourcing.Infrastructure/EjemploEventSourcing.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/EjemploEventSourcing.Infrastructure/Migrations/20201020200905_initial.cs
+++ b/EjemploEventSourcing.Infrastructure/Migrations/20201020200905_initial.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace EjemploEventSourcing.Migrations
 {
-    public partial class initial : Migration
+    public partial class Initial : Migration
     {
         protected override void Up(MigrationBuilder migrationBuilder)
         {

--- a/EjemploEventSourcing.Infrastructure/Migrations/20260430181835_UpgradeEfCore10UtcTimestamps.Designer.cs
+++ b/EjemploEventSourcing.Infrastructure/Migrations/20260430181835_UpgradeEfCore10UtcTimestamps.Designer.cs
@@ -7,21 +7,25 @@ using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
+#nullable disable
+
 namespace EjemploEventSourcing.Migrations
 {
     [DbContext(typeof(EventStoreDBContext))]
-    [Migration("20201020200905_initial")]
-    partial class Initial
+    [Migration("20260430181835_UpgradeEfCore10UtcTimestamps")]
+    partial class UpgradeEfCore10UtcTimestamps
     {
+        /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
-                .HasAnnotation("ProductVersion", "3.1.9")
+                .HasAnnotation("ProductVersion", "10.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            modelBuilder.Entity("EjemploEventSourcing.Infraestructura.Repositorios.Aggregate", b =>
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+
+            modelBuilder.Entity("EjemploEventSourcing.Infrastructure.Repositorios.Aggregate", b =>
                 {
                     b.Property<string>("Id")
                         .HasColumnType("text");
@@ -37,7 +41,7 @@ namespace EjemploEventSourcing.Migrations
                     b.ToTable("Aggregates");
                 });
 
-            modelBuilder.Entity("EjemploEventSourcing.Infraestructura.Repositorios.Event", b =>
+            modelBuilder.Entity("EjemploEventSourcing.Infrastructure.Repositorios.Event", b =>
                 {
                     b.Property<string>("AggregateId")
                         .HasColumnType("text");
@@ -49,8 +53,7 @@ namespace EjemploEventSourcing.Migrations
                         .HasColumnType("jsonb");
 
                     b.Property<DateTime>("DateTimeCreate")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("EventType")
                         .HasColumnType("integer");

--- a/EjemploEventSourcing.Infrastructure/Migrations/20260430181835_UpgradeEfCore10UtcTimestamps.cs
+++ b/EjemploEventSourcing.Infrastructure/Migrations/20260430181835_UpgradeEfCore10UtcTimestamps.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EjemploEventSourcing.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpgradeEfCore10UtcTimestamps : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DateTimeCreate",
+                table: "Events",
+                type: "timestamp with time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp without time zone");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "DateTimeCreate",
+                table: "Events",
+                type: "timestamp without time zone",
+                nullable: false,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+        }
+    }
+}

--- a/EjemploEventSourcing.Infrastructure/Migrations/EventStoreDBContextModelSnapshot.cs
+++ b/EjemploEventSourcing.Infrastructure/Migrations/EventStoreDBContextModelSnapshot.cs
@@ -6,6 +6,8 @@ using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
+#nullable disable
+
 namespace EjemploEventSourcing.Migrations
 {
     [DbContext(typeof(EventStoreDBContext))]
@@ -15,11 +17,12 @@ namespace EjemploEventSourcing.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
-                .HasAnnotation("ProductVersion", "3.1.9")
+                .HasAnnotation("ProductVersion", "10.0.7")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            modelBuilder.Entity("EjemploEventSourcing.Infraestructura.Repositorios.Aggregate", b =>
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+
+            modelBuilder.Entity("EjemploEventSourcing.Infrastructure.Repositorios.Aggregate", b =>
                 {
                     b.Property<string>("Id")
                         .HasColumnType("text");
@@ -35,7 +38,7 @@ namespace EjemploEventSourcing.Migrations
                     b.ToTable("Aggregates");
                 });
 
-            modelBuilder.Entity("EjemploEventSourcing.Infraestructura.Repositorios.Event", b =>
+            modelBuilder.Entity("EjemploEventSourcing.Infrastructure.Repositorios.Event", b =>
                 {
                     b.Property<string>("AggregateId")
                         .HasColumnType("text");
@@ -47,8 +50,7 @@ namespace EjemploEventSourcing.Migrations
                         .HasColumnType("jsonb");
 
                     b.Property<DateTime>("DateTimeCreate")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int>("EventType")
                         .HasColumnType("integer");

--- a/EjemploEventSourcing.IoC/EjemploEventSourcing.IoC.csproj
+++ b/EjemploEventSourcing.IoC/EjemploEventSourcing.IoC.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EjemploEventSourcing.Tests/EjemploEventSourcing.Tests.csproj
+++ b/EjemploEventSourcing.Tests/EjemploEventSourcing.Tests.csproj
@@ -1,15 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/EjemploEventSourcing/EjemploEventSourcing.Application.csproj
+++ b/EjemploEventSourcing/EjemploEventSourcing.Application.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.8">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.8.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.6.2" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="6.6.2" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="7.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.7" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Application\Domain\" />

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ejemplo de Event Sourcing con ASP.NET Core, PostgreSQL como event store y Rabbit
 
 ## Requisitos
 
-- .NET SDK 8
+- .NET SDK 10
 - Docker
 
 ## Dependencias locales
@@ -42,7 +42,7 @@ dotnet ef database update \
 Si `dotnet ef` no está instalado:
 
 ```bash
-dotnet tool install --global dotnet-ef --version 8.0.8
+dotnet tool install --global dotnet-ef --version 10.0.7
 ```
 
 ## Ejecutar

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.203",
+    "rollForward": "latestFeature"
+  }
+}

--- a/script/smoke/local-account-flow.sh
+++ b/script/smoke/local-account-flow.sh
@@ -3,7 +3,8 @@ set -euo pipefail
 
 API_URL="${API_URL:-http://127.0.0.1:5110}"
 DEPOSIT_AMOUNT="${DEPOSIT_AMOUNT:-100}"
-DOTNET_EF_VERSION="${DOTNET_EF_VERSION:-8.0.8}"
+DOTNET_CMD="${DOTNET_CMD:-dotnet}"
+DOTNET_EF_VERSION="${DOTNET_EF_VERSION:-10.0.7}"
 DOWN_DEPS=false
 RESET_DATA=false
 
@@ -52,6 +53,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 API_LOG="$(mktemp "${TMPDIR:-/tmp}/ejemplo-event-sourcing-api.XXXXXX")"
 API_PID=""
+
+if [[ "${DOTNET_CMD}" == */* ]]; then
+  DOTNET_CMD_DIR="$(cd "$(dirname "${DOTNET_CMD}")" && pwd)"
+  export DOTNET_ROOT="${DOTNET_ROOT:-${DOTNET_CMD_DIR}}"
+  export PATH="${DOTNET_CMD_DIR}:${PATH}"
+fi
 
 log() {
   printf '[smoke] %s\n' "$*"
@@ -119,21 +126,23 @@ wait_for_service_health() {
 }
 
 resolve_dotnet_ef() {
-  if dotnet ef --version >/dev/null 2>&1; then
-    DOTNET_EF=(dotnet ef)
+  local tool_path="/tmp/dotnet-tools-${DOTNET_EF_VERSION}"
+
+  if [[ "$("${DOTNET_CMD}" ef --version 2>/dev/null || true)" == "${DOTNET_EF_VERSION}"* ]]; then
+    DOTNET_EF=("${DOTNET_CMD}" ef)
     return 0
   fi
 
-  if [[ -x /tmp/dotnet-tools/dotnet-ef ]]; then
-    DOTNET_EF=(/tmp/dotnet-tools/dotnet-ef)
+  if [[ -x "${tool_path}/dotnet-ef" ]]; then
+    DOTNET_EF=("${tool_path}/dotnet-ef")
     return 0
   fi
 
-  log "Installing dotnet-ef ${DOTNET_EF_VERSION} into /tmp/dotnet-tools"
-  dotnet tool install dotnet-ef \
+  log "Installing dotnet-ef ${DOTNET_EF_VERSION} into ${tool_path}"
+  "${DOTNET_CMD}" tool install dotnet-ef \
     --version "${DOTNET_EF_VERSION}" \
-    --tool-path /tmp/dotnet-tools >/dev/null
-  DOTNET_EF=(/tmp/dotnet-tools/dotnet-ef)
+    --tool-path "${tool_path}" >/dev/null
+  DOTNET_EF=("${tool_path}/dotnet-ef")
 }
 
 wait_for_api() {
@@ -176,7 +185,7 @@ assert_queue_messages_at_least() {
 }
 
 require_command docker
-require_command dotnet
+require_command "${DOTNET_CMD}"
 require_command curl
 
 cd "${REPO_ROOT}"
@@ -204,7 +213,7 @@ log "Applying EF Core migrations"
   --startup-project EjemploEventSourcing.API
 
 log "Starting API on ${API_URL}"
-dotnet run --no-launch-profile \
+"${DOTNET_CMD}" run --no-launch-profile \
   --project EjemploEventSourcing.API \
   --urls "${API_URL}" >"${API_LOG}" 2>&1 &
 API_PID="$!"
@@ -212,19 +221,25 @@ API_PID="$!"
 wait_for_api
 
 log "Creating account"
-account_response="$(curl -fsS -X POST "${API_URL}/CreateAccount")"
+if ! account_response="$(curl -fsS -X POST "${API_URL}/CreateAccount")"; then
+  fail "CreateAccount request failed"
+fi
 account_id="${account_response%\"}"
 account_id="${account_id#\"}"
 [[ -n "${account_id}" ]] || fail "CreateAccount did not return an account id"
 log "Created account ${account_id}"
 
 log "Depositing ${DEPOSIT_AMOUNT}"
-curl -fsS -X POST "${API_URL}/DepositAmount" \
+if ! curl -fsS -X POST "${API_URL}/DepositAmount" \
   -H "Content-Type: application/json" \
-  -d "{\"accountId\":\"${account_id}\",\"depositAmount\":${DEPOSIT_AMOUNT}}" >/dev/null
+  -d "{\"accountId\":\"${account_id}\",\"depositAmount\":${DEPOSIT_AMOUNT}}" >/dev/null; then
+  fail "DepositAmount request failed"
+fi
 
 log "Reading account ${account_id}"
-account_json="$(curl -fsS "${API_URL}/GetAccountById/${account_id}")"
+if ! account_json="$(curl -fsS "${API_URL}/GetAccountById/${account_id}")"; then
+  fail "GetAccountById request failed"
+fi
 case "${account_json}" in
   *"\"id\":\"${account_id}\""*"\"balance\":${DEPOSIT_AMOUNT}"*)
     log "Balance verified: ${DEPOSIT_AMOUNT}"


### PR DESCRIPTION
## Summary

Migra la solucion a .NET 10 LTS y actualiza dependencias principales para compilar y ejecutar el flujo local completo.

## Changes

- Cambia todos los proyectos a net10.0 y agrega global.json con SDK 10.0.203.
- Actualiza EF Core, Npgsql, paquetes Microsoft.Extensions, Swashbuckle, RabbitMQ.Client y paquetes de test.
- Adapta RabbitMQ.Client 7 usando APIs async en publishers y consumers.
- Agrega migracion EF Core 10 para DateTimeCreate como timestamp with time zone, consistente con DateTime.UtcNow.
- Actualiza README y smoke script para dotnet-ef 10.0.7, DOTNET_CMD y mejor logging ante errores HTTP.

## Why

Para dejar el repo sobre la version LTS vigente antes de armar CI y resolver ahora los cambios de compatibilidad de runtime, EF Core/Npgsql y RabbitMQ.

## Scope

- [x] Docs
- [x] API
- [ ] Domain / Events
- [x] Persistence
- [x] Messaging
- [x] Infra / Config

## Testing

- [x] Manual
- [x] Unit tests
- [ ] Not applicable

Validado con SDK 10.0.203 instalado temporalmente en /private/tmp/dotnet10:

- /private/tmp/dotnet10/dotnet restore EjemploEventSourcing.sln
- /private/tmp/dotnet10/dotnet build EjemploEventSourcing.sln --no-restore -m:1 -v:minimal --disable-build-servers
- /private/tmp/dotnet10/dotnet test EjemploEventSourcing.sln --no-build -m:1 -v:minimal --disable-build-servers
- DOTNET_CMD=/private/tmp/dotnet10/dotnet script/smoke/local-account-flow.sh --reset-data --down-deps

Resultado: build con 0 warnings, 14 unit tests OK y smoke completo OK con balance 100 y colas RabbitMQ verificadas.

## Notes

La migracion cambia Events.DateTimeCreate a timestamp with time zone porque Npgsql 10 rechaza DateTime UTC contra timestamp without time zone. El smoke final apago API y dependencias.