### PR TITLE
chore: upgrade rabbitmq docker image

### DIFF
--- a/script/Docker/RabbitMQ/Dockerfile
+++ b/script/Docker/RabbitMQ/Dockerfile
@@ -1,4 +1,4 @@
-FROM rabbitmq:3.8.3-management-alpine
+FROM rabbitmq:4.3.0-management-alpine
 
 LABEL maintainer="gustavoarielms@gmail.com"
 


### PR DESCRIPTION
## Summary

Actualiza la imagen base local de RabbitMQ a rabbitmq:4.3.0-management-alpine.

## Changes

- Cambia script/Docker/RabbitMQ/Dockerfile de rabbitmq:3.8.3-management-alpine a rabbitmq:4.3.0-management-alpine.
- Valida que la configuracion actual de RabbitMQ siga levantando con Docker Compose.
- Verifica el flujo completo de cuenta contra RabbitMQ 4.3.

## Why

Para mantener la dependencia local de RabbitMQ en una version actual antes de avanzar con CI.

## Scope

- [ ] Docs
- [ ] API
- [ ] Domain / Events
- [ ] Persistence
- [x] Messaging
- [x] Infra / Config

## Testing

- [x] Manual
- [ ] Unit tests
- [ ] Not applicable

Validado con:

- DOTNET_CMD=/private/tmp/dotnet10/dotnet script/smoke/local-account-flow.sh --reset-data --down-deps

Resultado: smoke completo OK, balance 100 y colas RabbitMQ verificadas.

## Notes

El smoke apago API y dependencias al finalizar.